### PR TITLE
Bump QEMU to version 6.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Resources Changelog
 
+* Bump QEMU to 6.2.0
+
 ## 0.3.1
 
 ### New/Changed Features:


### PR DESCRIPTION
Starting with 6.2.0 the hvf accelerator could be used to improve
QEMU's performance in Apple Silicon.

Upgrade to that version (using a release package to simplify/speed
process) and while at it, prepare the script to be runnable in a
macOS M1 runner or a local workstation.