### PR TITLE
Bump QEMU to 8.0.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Resources Changelog
 
+## Unreleased
+
+### New/Changed Features
+
+* Bump QEMU to 8.0.0
+
 ## 0.7.0
 
 ### New/Changed Features

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### New/Changed Features
 
-* Bump QEMU to 8.0.0
+* Bump QEMU to 8.0.2
 
 ## 0.7.0
 

--- a/ci.rb
+++ b/ci.rb
@@ -222,7 +222,7 @@ class Qemu
        .concat(ci_runner.qemu_build_flags)
 
       execute "../configure", *args, env: { LDFLAGS: ldflags }
-      execute "make"
+      execute "make qemu-img qemu-system-aarch64 qemu-system-x86_64"
       execute "ls", "-lh"
     end
   ensure
@@ -395,7 +395,6 @@ class CIRunner
           '-lffi',
           "-liconv",
           "-lresolv",
-          "-lz",
           "#{brew_prefix}/opt/gettext/lib/libintl.a",
           "#{brew_prefix}/opt/glib/lib/libgio-2.0.a",
           "#{brew_prefix}/opt/glib/lib/libglib-2.0.a",

--- a/ci.rb
+++ b/ci.rb
@@ -7,7 +7,7 @@ require "tmpdir"
 
 class Qemu
   # Version of QEMU to bundle
-  VERSION = "7.2.0"
+  VERSION = "8.0.0"
 
   # Map of canonicalized host architectures
   ALIASES = {
@@ -180,7 +180,6 @@ class Qemu
         --disable-bochs
         --disable-bsd-user
         --disable-cfi-debug
-        --disable-cocoa
         --disable-curses
         --disable-debug-info
         --disable-debug-mutex
@@ -396,6 +395,7 @@ class CIRunner
           '-lffi',
           "-liconv",
           "-lresolv",
+          "-lz",
           "#{brew_prefix}/opt/gettext/lib/libintl.a",
           "#{brew_prefix}/opt/glib/lib/libgio-2.0.a",
           "#{brew_prefix}/opt/glib/lib/libglib-2.0.a",

--- a/ci.rb
+++ b/ci.rb
@@ -7,7 +7,7 @@ require "tmpdir"
 
 class Qemu
   # Version of QEMU to bundle
-  VERSION = "8.0.0"
+  VERSION = "8.0.2"
 
   # Map of canonicalized host architectures
   ALIASES = {

--- a/ci.sh
+++ b/ci.sh
@@ -172,7 +172,7 @@ build_qemu() {
     --target-list="$(join , "${qemu_platforms[@]/%/-softmmu}")" \
     $build_flags
 
-  make
+  make qemu-img qemu-system-aarch64 qemu-system-x86_64
   ls -lh
   popd > /dev/null
 }


### PR DESCRIPTION
- cocoa have to be enabled else the objective-c compiler is not found (required to compile .m files)
- link with zlib was added to build qemu tests correctly