### PR TITLE
Stop bundling the Linaro UEFI firmware for ARM64

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+* Stop bundling the Linaro UEFI firmware for ARM64. `linaro_uefi.fd` is no
+  longer part of the `qemu-system-aarch64` tarball. Its only consumer, OpenBSD
+  ARM64, now boots on the shared edk2 `uefi.fd` with ACPI disabled
+  ([cross-platform-actions/action#160](https://github.com/cross-platform-actions/action/pull/160)).
+  The Linaro release server it was downloaded from has been retired and
+  redirects to a landing page, so 1.1.0 shipped an HTML page in its place
+
+### Fixed
+
+* Fail the build when a download returns an unsuccessful HTTP status or an HTML
+  document instead of the requested file
+* Verify the contents of the bundled firmware files, not only their presence
+
 ## [1.1.0] - 2026-07-26
 
 ### Added

--- a/ci.rb
+++ b/ci.rb
@@ -120,8 +120,6 @@ class Qemu
       File.open(uefi_target_path, File::RDWR) do |file|
         file.truncate(file.read.bytes.rindex { _1 != 0 })
       end
-
-      bundle_linaro_uefi
     end
 
     private
@@ -140,19 +138,6 @@ class Qemu
 
       FileUtils.rm_f uefi_source_path
       unpack_bzip2 archive
-    end
-
-    def bundle_linaro_uefi
-      download_file(linaro_uefi_url, linaro_uefi_target_path)
-    end
-
-    def linaro_uefi_url
-      "https://releases.linaro.org/components/kernel/uefi-linaro/latest/release/qemu64/QEMU_EFI.fd"
-    end
-
-    def linaro_uefi_target_path
-      @linaro_uefi_target_path ||=
-        File.join(firmware_target_directory, "linaro_uefi.fd")
     end
   end
 
@@ -583,10 +568,32 @@ def execute(*args, env: {})
   Kernel.system env, *args, exception: true
 end
 
+HTML_CONTENT_TYPES = %w[text/html application/xhtml+xml].freeze
+
+HTML_SIGNATURE = /\A\s*<(?:!doctype\s+html|html[\s>])/i
+
+# Downloads a file, refusing to write anything but the requested payload. A
+# retired host that redirects to a landing page answers with a successful
+# status and an HTML body, which would otherwise silently be bundled as if it
+# were the expected file.
 def download_file(url, destination)
-  URI.open(url) do |uri|
-    File.open(destination, 'w') { _1.write(uri.read) }
+  URI.open(url) do |io|
+    content = io.read
+    validate_download(url, io, content)
+    File.binwrite(destination, content)
   end
+end
+
+def validate_download(url, io, content)
+  raise "Failed to download #{url}: HTTP #{Array(io.status).join(' ')}" unless successful_response?(io)
+  raise "Failed to download #{url}: expected a file, got an HTML document" if html?(io, content)
+end
+
+def successful_response?(io) = Array(io.status).first.to_s.start_with?("2")
+
+def html?(io, content)
+  HTML_CONTENT_TYPES.include?(io.content_type) ||
+    HTML_SIGNATURE.match?(content.byteslice(0, 1024).b)
 end
 
 def unpack_bzip2(archive)

--- a/test.rb
+++ b/test.rb
@@ -22,6 +22,11 @@ def assert_qemu_system(architecture, firmwares:)
   assert validator.valid?, validator.message
 end
 
+def assert_usable_firmwares(architecture)
+  validator = FirmwareValidator.new(architecture)
+  assert validator.valid?, validator.message
+end
+
 def assert_only_system_dependencies(architecture)
   return unless QemuSystemValidator.host_os == "macos"
 
@@ -62,6 +67,10 @@ describe "resources" do
         ]
       end
 
+      it "contains usable firmware files for x86_64" do
+        assert_usable_firmwares "x86_64"
+      end
+
       it "is only linked with system dependencies" do
         assert_only_system_dependencies "x86_64"
       end
@@ -77,8 +86,11 @@ describe "resources" do
           efi-e1000.rom
           efi-virtio.rom
           uefi.fd
-          linaro_uefi.fd
         ]
+      end
+
+      it "contains usable firmware files for arm64" do
+        assert_usable_firmwares "aarch64"
       end
 
       it "is only linked with system dependencies" do
@@ -97,6 +109,10 @@ describe "resources" do
           opensbi-riscv64-generic-fw_dynamic.bin
           u-boot.bin
         ]
+      end
+
+      it "contains usable firmware files for riscv64" do
+        assert_usable_firmwares "riscv64"
       end
 
       it "is only linked with system dependencies" do
@@ -200,6 +216,24 @@ class QemuSystemValidator
       @firmware_paths ||= paths.filter { _1.start_with?(firmware_directory) }
     end
 
+    # The contents have to be read while the archive is being iterated, an
+    # entry cannot be read after the reader has moved past it.
+    def firmware_files
+      @firmware_files ||= File.open(filename) do |io|
+        firmware_files = []
+
+        Gem::Package::TarReader.new(io) do |tar|
+          tar.each do |entry|
+            next unless firmware?(entry)
+
+            firmware_files << Firmware.new(basename(entry), entry.read.to_s)
+          end
+        end
+
+        firmware_files
+      end
+    end
+
     def qemu_binary
       @qemu_binary ||= paths.filter { _1.start_with?("bin/qemu") }
     end
@@ -211,6 +245,16 @@ class QemuSystemValidator
     def firmware_directory
       "share/qemu/"
     end
+
+    private
+
+    def firmware?(entry)
+      entry.file? && full_name(entry).start_with?(firmware_directory)
+    end
+
+    def basename(entry) = full_name(entry).delete_prefix(firmware_directory)
+
+    def full_name(entry) = entry.full_name.delete_prefix("./")
   end
 
   class MessageFormatter
@@ -265,4 +309,71 @@ class QemuSystemValidator
       array.map { File.join(tar_file.firmware_directory, _1) }
     end
   end
+end
+
+# Verifies that the bundled firmware files actually contain firmware. A failed
+# download can produce an HTML error or landing page, which is otherwise
+# indistinguishable from a correct bundle since the file is still present.
+class FirmwareValidator
+  def initialize(architecture)
+    @architecture = architecture
+  end
+
+  def valid? = unusable_firmwares.empty?
+
+  def message
+    ["Unusable firmware files in '#{tar_file.filename}':"]
+      .concat(unusable_firmwares.map(&:message))
+      .join("\n")
+  end
+
+  private
+
+  attr_reader :architecture
+
+  def unusable_firmwares
+    @unusable_firmwares ||= tar_file.firmware_files.reject(&:usable?)
+  end
+
+  def tar_file
+    @tar_file ||= QemuSystemValidator::TarFile.for(
+      architecture: architecture,
+      host_os: QemuSystemValidator.host_os
+    )
+  end
+end
+
+# A single firmware file extracted from a bundle.
+class Firmware
+  # The smallest firmware bundled, kvmvapic.bin, is a few kilobytes.
+  MINIMUM_SIZE = 4096
+
+  private_constant :MINIMUM_SIZE
+
+  HTML_SIGNATURE = /\A\s*<(?:!doctype\s+html|html[\s>])/i
+
+  private_constant :HTML_SIGNATURE
+
+  attr_reader :name
+
+  def initialize(name, content)
+    @name = name
+    @content = content
+  end
+
+  def usable? = !html? && large_enough?
+
+  def message
+    return "'#{name}' is an HTML document, not firmware" if html?
+
+    "'#{name}' is #{content.bytesize} bytes, expected at least #{MINIMUM_SIZE}"
+  end
+
+  private
+
+  attr_reader :content
+
+  def html? = HTML_SIGNATURE.match?(content.byteslice(0, 1024).b)
+
+  def large_enough? = content.bytesize >= MINIMUM_SIZE
 end


### PR DESCRIPTION
## Problem

`Qemu::Arm64#bundle_uefi` downloaded `linaro_uefi.fd` from
`https://releases.linaro.org/components/kernel/uefi-linaro/latest/release/qemu64/QEMU_EFI.fd`.
That host has been retired: the URL now 302-redirects to
`https://www.linaro.org/contact/`, which answers with **HTTP 200 and an HTML
body**. `download_file` used `URI.open` and wrote whatever it received without
validation, so the 1.1.0 build silently bundled a 49381-byte HTML page
("Contact | Linaro") as `share/qemu/linaro_uefi.fd` (the correct file in 1.0.0
is 2097152 bytes).

`Arm64OpenBsd` in `cross-platform-actions/action` is the only consumer of that
firmware, so every OpenBSD ARM64 job fails.

`test.rb` did not catch it because the firmware assertions only checked that
the files were *present* in the tarball.

## Changes

* **Drop the Linaro firmware entirely.** OpenBSD ARM64 no longer needs it:
  cross-platform-actions/action#160 boots it on the shared edk2 `uefi.fd` by
  setting the machine type to `virt,acpi=off`. edk2 publishes ACPI tables and
  OpenBSD 7.x/arm64 hangs during ACPI attach; suppressing them makes the kernel
  fall back to the device tree, which is exactly what the old Linaro build
  offered. With no consumer left there is nothing to download and nothing to
  vendor, so `bundle_linaro_uefi`, `linaro_uefi_target_path` and the
  `linaro_uefi.fd` entry in the arm64 firmware list are gone.
* **`download_file` fails loudly.** It raises on a non-success HTTP status and
  on an HTML body (by `Content-Type` or by sniffing the leading bytes), and
  writes the destination only after validation, in binary mode. The check is
  generic, so the riscv64 U-Boot `.deb` download is protected too.
* **`test.rb` checks firmware contents.** A new `FirmwareValidator` reads every
  `share/qemu/*` entry out of the bundle and asserts it is at least 4 KiB and
  not an HTML document. Applied to x86_64, arm64 and riscv64.

This is a behavioural change for consumers of the tarball, so the changelog
records it under **Removed**: `qemu-system-aarch64-*.tar` no longer contains
`share/qemu/linaro_uefi.fd`.

Depends on cross-platform-actions/action#160 — that PR must ship for OpenBSD
ARM64 to keep booting once a release cut from this branch is consumed.

## Verification

The full suite needs built QEMU artifacts, so it cannot run locally.
`ruby -c ci.rb` and `ruby -c test.rb` both report `Syntax OK`.

The bundle assertions were run against three synthetic
`qemu-system-aarch64-macos.tar` fixtures:

| Fixture | File structure | Firmware contents |
| --- | --- | --- |
| `efi-e1000.rom`, `efi-virtio.rom`, `uefi.fd` | pass | pass |
| the above plus an HTML `linaro_uefi.fd` | fail — `+share/qemu/linaro_uefi.fd` | fail — `'linaro_uefi.fd' is an HTML document, not firmware` |
| `uefi.fd` truncated to 512 bytes | pass | fail — `'uefi.fd' is 512 bytes, expected at least 4096` |

The second row confirms both that the arm64 expectations no longer list
`linaro_uefi.fd` and that an unexpected extra firmware in the bundle is now a
failure.

The hardened `download_file` was exercised against a local HTTP server:

| Response | Result |
| --- | --- |
| 200, `application/octet-stream`, 64 KiB binary | written, bytes match |
| 200, `text/html` | raises "expected a file, got an HTML document", no file |
| 200, `application/octet-stream`, HTML body | raises "expected a file, got an HTML document", no file |
| 302 to a 200 `text/html` page | raises "expected a file, got an HTML document", no file |
| 404 | raises `OpenURI::HTTPError`, no file |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
